### PR TITLE
스톱워치 동작 중 임시 타임라인 피드 정보를 로컬 데이터베이스에 저장하기 위한 세팅

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,13 +18,7 @@
         android:theme="@style/Theme.GodFisherman">
         <activity
             android:name=".ui.stopwatch.StopwatchActivity2"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:exported="true"/>
         <activity
             android:name=".ui.camera.upload.UploadActivity"
             android:exported="false" />
@@ -36,6 +30,11 @@
             android:name=".ui.main.MainActivity"
             android:exported="true"
             android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,11 @@
         <activity
             android:name=".ui.stopwatch.StopwatchActivity2"
             android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".ui.camera.upload.UploadActivity"
@@ -31,11 +36,6 @@
             android:name=".ui.main.MainActivity"
             android:exported="true"
             android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/java/com/android04/godfisherman/data/datasource/stopwatchdatasource/StopwatchDataSource.kt
+++ b/app/src/main/java/com/android04/godfisherman/data/datasource/stopwatchdatasource/StopwatchDataSource.kt
@@ -1,0 +1,8 @@
+package com.android04.godfisherman.data.datasource.stopwatchdatasource
+
+interface StopwatchDataSource {
+
+    interface LocalDataSource{}
+
+    interface RemoteDataSource{}
+}

--- a/app/src/main/java/com/android04/godfisherman/data/datasource/stopwatchdatasource/local/StopwatchLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/android04/godfisherman/data/datasource/stopwatchdatasource/local/StopwatchLocalDataSourceImpl.kt
@@ -1,0 +1,11 @@
+package com.android04.godfisherman.data.datasource.stopwatchdatasource.local
+
+import com.android04.godfisherman.data.datasource.stopwatchdatasource.StopwatchDataSource
+import com.android04.godfisherman.localdatabase.dao.TemporaryFishingRecordDao
+import javax.inject.Inject
+
+class StopwatchLocalDataSourceImpl @Inject constructor(
+    private val temporaryFishingRecordDao: TemporaryFishingRecordDao
+) : StopwatchDataSource.LocalDataSource {
+
+}

--- a/app/src/main/java/com/android04/godfisherman/data/repository/StopwatchRepository.kt
+++ b/app/src/main/java/com/android04/godfisherman/data/repository/StopwatchRepository.kt
@@ -1,0 +1,10 @@
+package com.android04.godfisherman.data.repository
+
+import com.android04.godfisherman.data.datasource.stopwatchdatasource.StopwatchDataSource
+import javax.inject.Inject
+
+class StopwatchRepository @Inject constructor(
+    private val localDataSource: StopwatchDataSource.LocalDataSource
+) {
+
+}

--- a/app/src/main/java/com/android04/godfisherman/di/LocalDatabaseDiModule.kt
+++ b/app/src/main/java/com/android04/godfisherman/di/LocalDatabaseDiModule.kt
@@ -1,0 +1,32 @@
+package com.android04.godfisherman.di
+
+import android.content.Context
+import androidx.room.Room
+import com.android04.godfisherman.localdatabase.LocalDatabase
+import com.android04.godfisherman.localdatabase.dao.TemporaryFishingRecordDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class LocalDatabaseDiModule {
+
+    @Provides
+    fun providesTemporaryFishingRecordDao(localDatabase: LocalDatabase): TemporaryFishingRecordDao {
+        return localDatabase.temporaryFishingRecordDao()
+    }
+
+    @Provides
+    @Singleton
+    fun providesLocalDatabase(@ApplicationContext context: Context) : LocalDatabase{
+        return Room.databaseBuilder(
+            context.applicationContext,
+            LocalDatabase::class.java,
+            "local_database"
+        ).build()
+    }
+}

--- a/app/src/main/java/com/android04/godfisherman/di/StopwatchDiModule.kt
+++ b/app/src/main/java/com/android04/godfisherman/di/StopwatchDiModule.kt
@@ -1,0 +1,18 @@
+package com.android04.godfisherman.di
+
+import com.android04.godfisherman.data.datasource.stopwatchdatasource.StopwatchDataSource
+import com.android04.godfisherman.data.datasource.stopwatchdatasource.local.StopwatchLocalDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+@Module
+@InstallIn(ViewModelComponent::class)
+abstract class StopwatchDiModule {
+
+    @Binds
+    abstract fun bindStopwatchLocalDataSource(
+        localDataSourceImpl: StopwatchLocalDataSourceImpl
+    ) : StopwatchDataSource.LocalDataSource
+}

--- a/app/src/main/java/com/android04/godfisherman/localdatabase/DatabaseTypeConverter.kt
+++ b/app/src/main/java/com/android04/godfisherman/localdatabase/DatabaseTypeConverter.kt
@@ -1,0 +1,16 @@
+package com.android04.godfisherman.localdatabase
+
+import androidx.room.TypeConverter
+import java.util.Date
+
+class DatabaseTypeConverter {
+    @TypeConverter
+    fun timeStampToDate(value: Long?): Date? {
+        return value?.let { Date(it) }
+    }
+
+    @TypeConverter
+    fun dateToTimestamp(date: Date?): Long? {
+        return date?.time
+    }
+}

--- a/app/src/main/java/com/android04/godfisherman/localdatabase/LocalDatabase.kt
+++ b/app/src/main/java/com/android04/godfisherman/localdatabase/LocalDatabase.kt
@@ -1,0 +1,36 @@
+package com.android04.godfisherman.localdatabase
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.android04.godfisherman.localdatabase.dao.TemporaryFishingRecordDao
+import com.android04.godfisherman.localdatabase.entity.TemporaryFishingRecord
+
+@Database(entities = [TemporaryFishingRecord::class], version = 1, exportSchema = false)
+@TypeConverters(DatabaseTypeConverter::class)
+abstract class LocalDatabase : RoomDatabase() {
+
+    abstract fun temporaryFishingRecordDao(): TemporaryFishingRecordDao
+
+    companion object {
+
+        @Volatile
+        private var INSTANCE: LocalDatabase? = null
+
+        fun getInstance(context: Context): LocalDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    LocalDatabase::class.java,
+                    "local_database"
+                ).build()
+                INSTANCE = instance
+                // return instance
+                instance
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/com/android04/godfisherman/localdatabase/LocalDatabase.kt
+++ b/app/src/main/java/com/android04/godfisherman/localdatabase/LocalDatabase.kt
@@ -14,23 +14,23 @@ abstract class LocalDatabase : RoomDatabase() {
 
     abstract fun temporaryFishingRecordDao(): TemporaryFishingRecordDao
 
-    companion object {
-
-        @Volatile
-        private var INSTANCE: LocalDatabase? = null
-
-        fun getInstance(context: Context): LocalDatabase {
-            return INSTANCE ?: synchronized(this) {
-                val instance = Room.databaseBuilder(
-                    context.applicationContext,
-                    LocalDatabase::class.java,
-                    "local_database"
-                ).build()
-                INSTANCE = instance
-                // return instance
-                instance
-            }
-        }
-
-    }
+    // TODO Hilt로 의존성 받아올 수 있는지 확인하고 주석 삭제
+//    companion object {
+//
+//        @Volatile
+//        private var INSTANCE: LocalDatabase? = null
+//
+//        fun getInstance(context: Context): LocalDatabase {
+//            return INSTANCE ?: synchronized(this) {
+//                val instance = Room.databaseBuilder(
+//                    context.applicationContext,
+//                    LocalDatabase::class.java,
+//                    "local_database"
+//                ).build()
+//                INSTANCE = instance
+//                // return instance
+//                instance
+//            }
+//        }
+//    }
 }

--- a/app/src/main/java/com/android04/godfisherman/localdatabase/LocalDatabase.kt
+++ b/app/src/main/java/com/android04/godfisherman/localdatabase/LocalDatabase.kt
@@ -14,23 +14,4 @@ abstract class LocalDatabase : RoomDatabase() {
 
     abstract fun temporaryFishingRecordDao(): TemporaryFishingRecordDao
 
-    // TODO Hilt로 의존성 받아올 수 있는지 확인하고 주석 삭제
-//    companion object {
-//
-//        @Volatile
-//        private var INSTANCE: LocalDatabase? = null
-//
-//        fun getInstance(context: Context): LocalDatabase {
-//            return INSTANCE ?: synchronized(this) {
-//                val instance = Room.databaseBuilder(
-//                    context.applicationContext,
-//                    LocalDatabase::class.java,
-//                    "local_database"
-//                ).build()
-//                INSTANCE = instance
-//                // return instance
-//                instance
-//            }
-//        }
-//    }
 }

--- a/app/src/main/java/com/android04/godfisherman/localdatabase/dao/TemporaryFishingRecordDao.kt
+++ b/app/src/main/java/com/android04/godfisherman/localdatabase/dao/TemporaryFishingRecordDao.kt
@@ -8,7 +8,7 @@ import com.android04.godfisherman.localdatabase.entity.TemporaryFishingRecord
 @Dao
 interface TemporaryFishingRecordDao {
 
-    @Query("SELECT * FROM temporary_fishing_record WHERE userId == :userId")
+    @Query("SELECT * FROM temporary_fishing_record WHERE userId == :userId ORDER BY date ASC")
     fun getTemporaryRecords(userId: String): List<TemporaryFishingRecord>
 
     @Insert

--- a/app/src/main/java/com/android04/godfisherman/localdatabase/dao/TemporaryFishingRecordDao.kt
+++ b/app/src/main/java/com/android04/godfisherman/localdatabase/dao/TemporaryFishingRecordDao.kt
@@ -1,0 +1,19 @@
+package com.android04.godfisherman.localdatabase.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.android04.godfisherman.localdatabase.entity.TemporaryFishingRecord
+
+@Dao
+interface TemporaryFishingRecordDao {
+
+    @Query("SELECT * FROM temporary_fishing_record WHERE userId == :userId")
+    fun getTemporaryRecords(userId: String): List<TemporaryFishingRecord>
+
+    @Insert
+    suspend fun insert(record: TemporaryFishingRecord)
+
+    @Query("DELETE FROM temporary_fishing_record WHERE userId == :userId")
+    suspend fun delete(userId: String)
+}

--- a/app/src/main/java/com/android04/godfisherman/localdatabase/entity/TemporaryFishingRecord.kt
+++ b/app/src/main/java/com/android04/godfisherman/localdatabase/entity/TemporaryFishingRecord.kt
@@ -1,0 +1,16 @@
+package com.android04.godfisherman.localdatabase.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.Date
+
+@Entity(tableName = "temporary_fishing_record")
+data class TemporaryFishingRecord(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int,
+    val userId: String,
+    val imageUrl: String,
+    val date: Date,
+    val fishLength: Double,
+    val fishType: String
+)

--- a/app/src/main/java/com/android04/godfisherman/ui/stopwatch/StopWatchInfoTestViewModel.kt
+++ b/app/src/main/java/com/android04/godfisherman/ui/stopwatch/StopWatchInfoTestViewModel.kt
@@ -1,0 +1,13 @@
+package com.android04.godfisherman.ui.stopwatch
+
+import androidx.lifecycle.ViewModel
+import com.android04.godfisherman.data.repository.StopwatchRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class StopWatchInfoTestViewModel  @Inject constructor(
+    private val repository: StopwatchRepository
+) : ViewModel() {
+
+}

--- a/app/src/main/java/com/android04/godfisherman/ui/stopwatch/StopwatchActivity2.kt
+++ b/app/src/main/java/com/android04/godfisherman/ui/stopwatch/StopwatchActivity2.kt
@@ -3,11 +3,18 @@ package com.android04.godfisherman.ui.stopwatch
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.TextView
+import androidx.activity.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import com.android04.godfisherman.R
 import com.android04.godfisherman.utils.RecyclerViewEmptySupport
+import dagger.hilt.EntryPoint
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class StopwatchActivity2 : AppCompatActivity() {
+
+    val viewModel: StopWatchInfoTestViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_stopwatch)


### PR DESCRIPTION
### 이슈 번호✨
- #23 
- #28
- close:  


### PR 내용📢
- Room 데이터베이스 설정
- 임시 타임라인 피드 데이터 엔티티 생성 - TemporaryFishingRecord
- TemporaryFishingRecord 엔티티에 대한 DAO 생성
- 스톱워치 레포지토리 패턴 적용
- Hilt 로 의존성 주입 (레포지토리, 데이터소스, Room 데이터베이스)


### 논의할 사항😥
- DAO 에 쿼리를 만들어 놨는데 아직 테스트를 못해봤습니다. (더미 데이터를 넣고 확인하기가 애매하더라구요)
- 테스트는 스톱워치랑 업로드 연동할때 빠르게 테스트 해보면 될 것 같습니다.
- 일단 당장은 타임라인 피드정보를 저장할 엔티티만 등록해놨는데, 저희 캐싱 처리도 해야하면 엔티티가 더 생성될텐데 이 경우에 마이그레이션이 필요한 건가요?
- 다 구현하고 문득 생각이 들었는데, 이 정보가 로컬 디비에 저장해야할 필요가 있을까 싶기도 하더라구요, 이미지도 url 로 결국 string 값이면 이 정도의 객체 list는 스톱워치가 돌아가는 동안에 메모리에 유지하는게 큰 무리가 없지 않을까라는 생각이 들었습니다.


### https://www.notion.so/11-10-a92140d387944ef3ad3dd901848ada7a
- 그리고 이건 오늘 멘토님이 말씀해주신대로 개발 일지 느낌으로 써봤는데,생각보다 좋은 것 같아서 한번 해보시면 좋을 것 같아요!
