### PR TITLE
버그 수정

### DIFF
--- a/app/src/main/java/com/android04/godfisherman/common/LoadingDialogProvider.kt
+++ b/app/src/main/java/com/android04/godfisherman/common/LoadingDialogProvider.kt
@@ -1,0 +1,21 @@
+package com.android04.godfisherman.common
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.view.Window
+
+class LoadingDialogProvider {
+
+    fun provideLoadingDialog(context: Context, loadingLayout: Int): Dialog {
+
+        return Dialog(context).apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setCanceledOnTouchOutside(false)
+            setCancelable(false)
+            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            setContentView(loadingLayout)
+        }
+    }
+}

--- a/app/src/main/java/com/android04/godfisherman/data/repository/HomeRepository.kt
+++ b/app/src/main/java/com/android04/godfisherman/data/repository/HomeRepository.kt
@@ -71,8 +71,8 @@ class HomeRepository @Inject constructor(
         remoteDataSource.fetchWeatherData(lat, lon, callback)
     }
     
-    suspend fun fetchRankingList(): List<RankingData.HomeRankingData>
-    = remoteDataSource.fetchRankingList(10)
+    suspend fun fetchRankingList(num: Long): List<RankingData.HomeRankingData>
+    = remoteDataSource.fetchRankingList(num)
 
     suspend fun fetchWaitingRankingList(): List<RankingData.HomeWaitingRankingData>
     = remoteDataSource.fetchWaitingRankingList()

--- a/app/src/main/java/com/android04/godfisherman/ui/camera/upload/UploadActivity.kt
+++ b/app/src/main/java/com/android04/godfisherman/ui/camera/upload/UploadActivity.kt
@@ -4,13 +4,11 @@ import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Intent
 import android.content.pm.ActivityInfo
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
-import android.view.Window
 import android.widget.ArrayAdapter
 import androidx.activity.viewModels
 import com.android04.godfisherman.R
+import com.android04.godfisherman.common.LoadingDialogProvider
 import com.android04.godfisherman.databinding.ActivityUploadBinding
 import com.android04.godfisherman.ui.base.BaseActivity
 import com.android04.godfisherman.ui.camera.CameraActivity
@@ -23,7 +21,9 @@ class UploadActivity :
 
     override val viewModel: UploadViewModel by viewModels()
 
-    private lateinit var loadingDialog: Dialog
+    private val loadingDialog: Dialog by lazy {
+        LoadingDialogProvider().provideLoadingDialog(this, R.layout.dialog_upload_loading)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,7 +32,6 @@ class UploadActivity :
         initListener()
         setupObserver()
         setUpBinding()
-        setLoadingDialog()
         loadData()
 
     }
@@ -123,27 +122,11 @@ class UploadActivity :
         }
     }
 
-    private fun setLoadingDialog() {
-        val dialog = Dialog(this)
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        dialog.setCanceledOnTouchOutside(false)
-        dialog.setCancelable(false)
-        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-
-        dialog.setContentView(R.layout.dialog_upload_loading)
-
-        loadingDialog = dialog
-    }
-
     private fun showLoadingDialog() {
-        if (::loadingDialog.isInitialized) {
-            loadingDialog.show()
-        }
+        loadingDialog.show()
     }
 
     private fun cancelLoadingDialog() {
-        if (::loadingDialog.isInitialized) {
-            loadingDialog.cancel()
-        }
+        loadingDialog.cancel()
     }
 }

--- a/app/src/main/java/com/android04/godfisherman/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/android04/godfisherman/ui/home/HomeViewModel.kt
@@ -53,7 +53,7 @@ class HomeViewModel @Inject constructor(
 
     fun fetchRanking() {
         viewModelScope.launch(Dispatchers.IO) {
-            val list = homeRepository.fetchRankingList()
+            val list = homeRepository.fetchRankingList(5)
             _rankList.postValue(list)
         }
     }

--- a/app/src/main/java/com/android04/godfisherman/ui/home/RankingDetailViewModel.kt
+++ b/app/src/main/java/com/android04/godfisherman/ui/home/RankingDetailViewModel.kt
@@ -24,7 +24,7 @@ class RankingDetailViewModel @Inject constructor(
     fun fetchRanking() {
         viewModelScope.launch(Dispatchers.IO) {
             val diferredSizeRanking = async {
-                homeRepository.fetchRankingList()
+                homeRepository.fetchRankingList(10)
             }
             val diferredTimeRanking = async {
                 homeRepository.fetchWaitingRankingList()

--- a/app/src/main/java/com/android04/godfisherman/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/android04/godfisherman/ui/main/MainViewModel.kt
@@ -115,6 +115,7 @@ class MainViewModel @Inject constructor(
             }
         }
         _isAfterUpload.value = true
+        resetStopwatch()
     }
 
     private inner class StopwatchTask() : TimerTask() {

--- a/app/src/main/java/com/android04/godfisherman/ui/stopwatch/TestStopwatchFragment.kt
+++ b/app/src/main/java/com/android04/godfisherman/ui/stopwatch/TestStopwatchFragment.kt
@@ -79,7 +79,6 @@ class TestStopwatchFragment :
         binding.viewStartStop.setOnClickListener {
             if (viewModel.startOrStopTimer()) {
                 showDialog()
-                viewModel.resetStopwatch()
             }
         }
 

--- a/app/src/main/java/com/android04/godfisherman/utils/BindingAdapter.kt
+++ b/app/src/main/java/com/android04/godfisherman/utils/BindingAdapter.kt
@@ -138,10 +138,4 @@ object BindingAdapter {
     fun setWelcomeTextWithID(view: TextView, id: String) {
         view.text = "안녕하세요 ${id}님!"
     }
-
-    @JvmStatic
-    @BindingAdapter("setRankID")
-    fun setRankingTextWithIDAndRank(view: TextView, id: String) {
-        view.text = "이번 주 ${id}님의 전체 순위는 10위 입니다."
-    }
 }

--- a/app/src/main/java/com/android04/godfisherman/utils/RecyclerViewEmptySupport.kt
+++ b/app/src/main/java/com/android04/godfisherman/utils/RecyclerViewEmptySupport.kt
@@ -17,33 +17,26 @@ class RecyclerViewEmptySupport : RecyclerView {
     constructor (context: Context, attrs: AttributeSet) : super(context, attrs){}
 
     private var emptyView: View? = null
-    private val adapterDataObserver: AdapterDataObserver = object : AdapterDataObserver() {
-        override fun onChanged() {
-            super.onChanged()
 
-            val adapter = adapter
-
-            Log.d("TAG", "onChanged: ${adapter!!.itemCount}")
-            if (adapter != null && emptyView != null)
+    private fun onDataChanged() {
+        Log.d("TAG", "onChanged: ${adapter!!.itemCount}")
+        if (adapter != null && emptyView != null)
+        {
+            if (adapter!!.itemCount == 0)
             {
-                if (adapter.itemCount == 0)
-                {
-                    emptyView!!.visibility = View.VISIBLE
-                    this@RecyclerViewEmptySupport.visibility = View.GONE
-                }
-                else
-                {
-                    emptyView!!.visibility = View.GONE
-                    this@RecyclerViewEmptySupport.visibility = View.VISIBLE
-                }
+                emptyView!!.visibility = View.VISIBLE
+                this@RecyclerViewEmptySupport.visibility = View.GONE
+            } else
+            {
+                emptyView!!.visibility = View.GONE
+                this@RecyclerViewEmptySupport.visibility = View.VISIBLE
             }
         }
     }
 
     override fun setAdapter(adapter: Adapter<*>?) {
         super.setAdapter(adapter)
-        adapter?.registerAdapterDataObserver(adapterDataObserver)
-        adapterDataObserver.onChanged()
+        onDataChanged()
     }
 
     fun setEmptyView(emptyView: View) {
@@ -53,8 +46,10 @@ class RecyclerViewEmptySupport : RecyclerView {
     // RecyclerView Adpater 가 ListAdapter인 경우에만 사용
     fun <T> submitList(dataList: List<T>) {
         try {
-            (adapter as ListAdapter<T, *>).submitList(dataList)
-            adapterDataObserver.onChanged()
+            (adapter as ListAdapter<T, *>).submitList(dataList) {
+                onDataChanged()
+            }
+
         } catch (e: Exception) {
             // 이는 사용자가 아닌 개발자의 실라 별도의 예외처리 없이 로그 출력
             e.printStackTrace()

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -45,11 +45,11 @@
 
             <TextView
                 android:id="@+id/tv_user_ranking"
-                setRankID="@{viewModel.userName}"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/space_small"
                 android:layout_marginEnd="@dimen/space_large"
+                android:text="@string/welcome_help"
                 android:textSize="@dimen/text_median"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="@id/tv_user_name"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
 
     <!-- Home Fragment -->
     <string name="home_sample_id">안녕하세요 구전김박님!</string>
+    <string name="welcome_help">오늘도 그물잠과 함께 낚시를 즐겨보세요!</string>
     <string name="home_sample_rank_user">이번 주 구전김박님의 전체 순위는 10위입니다</string>
     <string name="home_this_week_rank">🐟이번 주 물고기 랭킹🐟</string>
     <string name="home_show_all">더보기</string>


### PR DESCRIPTION
### 이슈 번호✨
- 낫띵



### PR 내용📢
- 타임라인 업로드 시 시간이 0으로 업로드 되는 이슈 해결
- 스톱워치화면 리사이클러뷰 아이템의 첫번째 갱신이 무시되는 이슈 해결\
- LoadingDialogProvider 생성
- [참고](https://obtainable-anaconda-c76.notion.site/11-22-3e8d499f0d3249819f38f91e52513226)


### 논의할 사항😥
- 스톱워치를 종료하고 타임라인을 업로드 할 때도 사진 타입을 업로드할 때와 동일하게 다이얼로그를 사용할 것임
- 타임라인 데이터가 업로드가 완료되었다는 결과값이 오면 이에 맞게 다이얼로그를 on / off 하는 코드만 추가하면 됨
- 사진 타입 업로드 할 때와 타임라인 타입을 업로드할 때 모두 로딩 다이얼로그 뷰를 사용하기 위해 LoadingDialogProvider 생성
