### PR TITLE
HOTFIX: 스탑워치 종료 시 스탑워치 안내 화면이 나오고 하단 네비게이션이 맞지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/android04/godfisherman/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/android04/godfisherman/ui/main/MainActivity.kt
@@ -75,8 +75,6 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>(R.layout.a
             if (it) {
                 swipeMotionLayoutWrapper.transitionToState(R.id.end_close)
                 viewModel.stopwatchOnFlag.value = false
-                binding.navView.selectedItemId = R.id.navigation_stopwatch
-                changeFragment(R.id.fl_fragment_container, StopwatchInfoFragment())
                 viewModel.setIsAfterUploadFalse()
                 viewModel.isOpened = false
             }


### PR DESCRIPTION
### PR 내용 🚨
- 스탑워치 종료 시 스탑워치 안내 화면이 나오고 하단 네비게이션이 맞지 않는 문제 해결
